### PR TITLE
Fix for some potential input issues with the course code search field

### DIFF
--- a/schedule-generator/ca/uottawa/ui/ClientGUI.java
+++ b/schedule-generator/ca/uottawa/ui/ClientGUI.java
@@ -1,28 +1,27 @@
 package ca.uottawa.ui;
+import ca.uottawa.schedule.*;
+
 import javax.swing.*;
 import javax.swing.border.BevelBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
-
-import ca.uottawa.schedule.Activity;
-import ca.uottawa.schedule.Course;
-import ca.uottawa.schedule.CourseSelection;
-import ca.uottawa.schedule.Schedule;
-import ca.uottawa.schedule.Section;
-
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.DocumentFilter;
+import java.awt.*;
 import java.awt.event.*;
 import java.awt.image.BufferedImage;
-import java.awt.*;
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.text.DateFormatSymbols;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 public class ClientGUI implements ClientIF, ActionListener, DocumentListener, ItemListener, WindowListener, ListSelectionListener, MouseListener {
@@ -173,6 +172,20 @@ public class ClientGUI implements ClientIF, ActionListener, DocumentListener, It
 		//Text boxes
 		txtSearch.getDocument().addDocumentListener(this);
 		txtSearch.addActionListener(this);
+
+        ((AbstractDocument) this.txtSearch.getDocument()).setDocumentFilter(new DocumentFilter() {
+            final Pattern regEx = Pattern.compile("[A-Za-z0-9]+");
+            @Override
+            public void replace(FilterBypass fb, int offset, int length, String text, AttributeSet attrs) throws BadLocationException {
+                final Matcher matcher = this.regEx.matcher(text);
+                if ( !matcher.matches() ) {
+                    return;
+                }
+                if (ClientGUI.this.txtSearch.getText().length() <= 6) {
+                    super.replace(fb, offset, length, text, attrs);
+                }
+            }
+        });
 		
 		//ComboBoxes
 		cboSemester.addItemListener(this);

--- a/schedule-generator/ca/uottawa/ui/ScheduleGeneratorClient.java
+++ b/schedule-generator/ca/uottawa/ui/ScheduleGeneratorClient.java
@@ -1,15 +1,5 @@
 package ca.uottawa.ui;
 
-import java.io.File;
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.List;
-
-import javax.swing.JFileChooser;
-import javax.swing.filechooser.FileNameExtensionFilter;
-
 import biweekly.Biweekly;
 import biweekly.ICalendar;
 import biweekly.component.VEvent;
@@ -17,14 +7,15 @@ import biweekly.property.DateEnd;
 import biweekly.property.DateStart;
 import biweekly.util.Recurrence;
 import biweekly.util.Recurrence.Frequency;
-import ca.uottawa.schedule.Activity;
-import ca.uottawa.schedule.Course;
-import ca.uottawa.schedule.CourseSelection;
-import ca.uottawa.schedule.Schedule;
-import ca.uottawa.schedule.ScheduleMessage;
-import ca.uottawa.schedule.Section;
-
+import ca.uottawa.schedule.*;
 import com.lloseng.ocsf.client.AbstractClient;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
 
 public class ScheduleGeneratorClient extends AbstractClient {
 
@@ -203,8 +194,8 @@ public class ScheduleGeneratorClient extends AbstractClient {
 				srchMsg.setStrings(query);
 				srchMsg.setSemester(semester);
 				sendToServer(srchMsg);
-				break;
 			}
+            break;
 		case "ADD":
 			boolean issue = false; //This is a flag in case the command length is 3 but [2] is not OPTIONAL
 			if (command.length == 3) {


### PR DESCRIPTION
Hi Ted!

I saw someone posted this and took a look at it (as you can imagine, I have nothing better to do). I ran it and saw some potential issues that this commit can fix.

It looks like Ottawa U's course codes are all 7 digits, so adding a max length to the field prevents having to re-write other parts of your code that would break. Let me know if you need more details on that. I also threw in some filtering for only alpha-numeric characters, which prevents some exceptions with how the string is handled further into the code.

The back-end search of the course list is only concerned with the course code, so I don't think this breaks any functionality (users trying to enter the course title instead of code, for example).

I won't go into more detail here, since for the most part this will fix any potential issues with the way the input is handled, but let me know if you have any questions.

